### PR TITLE
feat: implement verified scoring and results flow

### DIFF
--- a/app/actions/assessment.ts
+++ b/app/actions/assessment.ts
@@ -7,6 +7,10 @@ import type {
   AttemptStatus,
   QuestionType,
 } from "@/lib/assessment/types";
+import {
+  persistCompletedAssessmentResults,
+  type CompletedAssessmentResults,
+} from "@/lib/assessment/scoring";
 import { ASSESSMENT_ATTEMPT_COOKIE_NAME } from "@/lib/assessment/tests";
 import { createSupabaseAdminClient } from "@/lib/supabase/admin";
 
@@ -33,6 +37,7 @@ type CompleteAssessmentAttemptResult =
       attemptId: string;
       completedAt: string;
       message: string;
+      results: CompletedAssessmentResults | null;
     }
   | {
       ok: false;
@@ -512,7 +517,9 @@ export async function completeAssessmentAttempt(
       return { ok: false, message: "Unable to complete attempt." };
     }
 
-    if (!completedAttemptData) {
+    let completedAttempt: AttemptRecord | null = completedAttemptData as AttemptRecord | null;
+
+    if (!completedAttempt) {
       const { data: existingAttemptData, error: existingAttemptError } = await supabase
         .from("attempts")
         .select("id, status, completed_at")
@@ -524,21 +531,15 @@ export async function completeAssessmentAttempt(
         return { ok: false, message: "Unable to confirm attempt completion." };
       }
 
-      if ((existingAttemptData as AttemptRecord | null)?.status === "completed") {
-        const attempt = existingAttemptData as AttemptRecord;
-
-        return {
-          ok: true,
-          attemptId: attempt.id,
-          completedAt: attempt.completed_at ?? completedAt,
-          message: "Assessment completed. Your answers are locked.",
-        };
+      if ((existingAttemptData as AttemptRecord | null)?.status !== "completed") {
+        return { ok: false, message: "Unable to complete attempt." };
       }
 
-      return { ok: false, message: "Unable to complete attempt." };
+      completedAttempt = existingAttemptData as AttemptRecord;
     }
 
-    const completedAttempt = completedAttemptData as AttemptRecord;
+    const results = await persistCompletedAssessmentResults(input.testId, persistResult.attemptId);
+
     cookies().set(ASSESSMENT_ATTEMPT_COOKIE_NAME, persistResult.attemptId, {
       httpOnly: true,
       sameSite: "lax",
@@ -550,6 +551,7 @@ export async function completeAssessmentAttempt(
       attemptId: persistResult.attemptId,
       completedAt: completedAttempt.completed_at ?? completedAt,
       message: "Assessment completed. Your answers are locked.",
+      results,
     };
   } catch (error) {
     console.error("completeAssessmentAttempt failed", error);

--- a/app/api/health/route.ts
+++ b/app/api/health/route.ts
@@ -1,0 +1,5 @@
+import { NextResponse } from "next/server";
+
+export function GET() {
+  return NextResponse.json({ ok: true });
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,6 +5,7 @@ import {
   getActiveTest,
   getAnswerOptionsForQuestions,
   getAssessmentResumeState,
+  getCompletedAssessmentResults,
   getQuestionsForTest,
 } from "@/lib/assessment/tests";
 
@@ -43,13 +44,12 @@ export default async function HomePage() {
       );
     }
 
+    const attemptId = cookies().get(ASSESSMENT_ATTEMPT_COOKIE_NAME)?.value;
     const answerOptionsByQuestionId = await getAnswerOptionsForQuestions(
       questions.map((question) => question.id),
     );
-    const resumeState = await getAssessmentResumeState(
-      test.id,
-      cookies().get(ASSESSMENT_ATTEMPT_COOKIE_NAME)?.value,
-    );
+    const resumeState = await getAssessmentResumeState(test.id, attemptId);
+    const results = await getCompletedAssessmentResults(test.id, resumeState.attemptId);
 
     return (
       <main>
@@ -67,6 +67,7 @@ export default async function HomePage() {
             initialAttemptStatus={resumeState.attemptStatus}
             initialCompletedAt={resumeState.completedAt}
             initialSelections={resumeState.selections}
+            initialResults={results}
           />
         </section>
       </main>

--- a/components/assessment/assessment-form.tsx
+++ b/components/assessment/assessment-form.tsx
@@ -5,6 +5,7 @@ import {
   completeAssessmentAttempt,
   saveAssessmentProgress,
 } from "@/app/actions/assessment";
+import type { CompletedAssessmentResults } from "@/lib/assessment/scoring";
 import type {
   AssessmentSelectionsInput,
   AssessmentSelectionValue,
@@ -20,6 +21,7 @@ type AssessmentFormProps = {
   initialAttemptId: string | null;
   initialAttemptStatus: AttemptStatus | null;
   initialCompletedAt: string | null;
+  initialResults: CompletedAssessmentResults | null;
 };
 
 type SelectionState = Record<string, AssessmentSelectionValue | undefined>;
@@ -43,6 +45,21 @@ function resetSaveFeedback(
   setSaveMessage(null);
 }
 
+function formatDimensionLabel(dimension: string): string {
+  return dimension
+    .split("_")
+    .map((part) => part.charAt(0).toUpperCase() + part.slice(1))
+    .join(" ");
+}
+
+function formatUnscoredReason(reason: CompletedAssessmentResults["unscoredResponses"][number]["reason"]): string {
+  if (reason === "question_type_not_scoreable") {
+    return "Recorded but not scored in the current MVP model.";
+  }
+
+  return "Recorded without numeric scoring values in the current seed data.";
+}
+
 export function AssessmentForm({
   testId,
   questions,
@@ -51,11 +68,13 @@ export function AssessmentForm({
   initialAttemptId,
   initialAttemptStatus,
   initialCompletedAt,
+  initialResults,
 }: AssessmentFormProps) {
   const [selections, setSelections] = useState<SelectionState>(initialSelections);
   const [attemptId, setAttemptId] = useState<string | null>(initialAttemptId);
   const [attemptStatus, setAttemptStatus] = useState<AttemptStatus | null>(initialAttemptStatus);
   const [completedAt, setCompletedAt] = useState<string | null>(initialCompletedAt);
+  const [results, setResults] = useState<CompletedAssessmentResults | null>(initialResults);
   const [saveStatus, setSaveStatus] = useState<SaveStatus>(
     initialAttemptStatus === "completed" ? "completed" : "idle",
   );
@@ -92,6 +111,7 @@ export function AssessmentForm({
       setAttemptId(result.attemptId);
       setAttemptStatus("in_progress");
       setCompletedAt(null);
+      setResults(null);
       setSaveStatus("saved");
       setSaveMessage(result.message);
     } catch {
@@ -124,6 +144,7 @@ export function AssessmentForm({
       setAttemptId(result.attemptId);
       setAttemptStatus("completed");
       setCompletedAt(result.completedAt);
+      setResults(result.results);
       setSaveStatus("completed");
       setSaveMessage(result.message);
     } catch {
@@ -172,7 +193,7 @@ export function AssessmentForm({
                 ) : options.length > 0 ? (
                   <ol>
                     {options.map((option) => {
-                      const inputId = `${question.id}-${option.id}`;
+                      const inputId = `${question.id}-${option.option_order}`;
 
                       if (question.question_type === "multiple_choice") {
                         const selectedOptionIds = Array.isArray(selection) ? selection : [];
@@ -252,6 +273,41 @@ export function AssessmentForm({
             {saveStatus === "completing" ? "Completing..." : "Complete assessment"}
           </button>
         </>
+      ) : null}
+
+      {results ? (
+        <section>
+          <h2>Results</h2>
+          <p>
+            Scoring method: {results.scoringMethod}. Scored responses: {results.scoredResponseCount}.
+          </p>
+
+          {results.dimensions.length > 0 ? (
+            <ol>
+              {results.dimensions.map((dimension) => (
+                <li key={dimension.dimension}>
+                  <strong>{formatDimensionLabel(dimension.dimension)}</strong>: raw score {dimension.rawScore}
+                  {` `}from {dimension.scoredQuestionCount} scored question(s).
+                </li>
+              ))}
+            </ol>
+          ) : (
+            <p>No scoreable responses are available for this completed attempt.</p>
+          )}
+
+          {results.unscoredResponses.length > 0 ? (
+            <>
+              <h3>Recorded but unscored responses</h3>
+              <ol>
+                {results.unscoredResponses.map((response) => (
+                  <li key={response.questionId}>
+                    <strong>{response.questionCode}</strong>: {formatUnscoredReason(response.reason)}
+                  </li>
+                ))}
+              </ol>
+            </>
+          ) : null}
+        </section>
       ) : null}
 
       {saveMessage ? <p>{saveMessage}</p> : null}

--- a/lib/assessment/scoring.ts
+++ b/lib/assessment/scoring.ts
@@ -1,0 +1,402 @@
+import type { QuestionType, ScoringMethod } from "@/lib/assessment/types";
+import { createSupabaseAdminClient } from "@/lib/supabase/admin";
+
+type AttemptRecord = {
+  id: string;
+  status: "in_progress" | "completed" | "abandoned";
+};
+
+type TestRecord = {
+  id: string;
+  scoring_method: ScoringMethod;
+};
+
+type QuestionRecord = {
+  id: string;
+  code: string;
+  text: string;
+  dimension: string;
+  question_type: QuestionType;
+  question_order: number;
+  reverse_scored: boolean;
+  weight: number;
+};
+
+type AnswerOptionRecord = {
+  id: string;
+  question_id: string;
+  value: number | null;
+};
+
+type ResponseRecord = {
+  id: string;
+  question_id: string;
+  response_kind: QuestionType;
+  answer_option_id: string | null;
+  raw_value: number | null;
+  scored_value: number | null;
+};
+
+export type CompletedAssessmentResultDimension = {
+  dimension: string;
+  rawScore: number;
+  scoredQuestionCount: number;
+};
+
+export type CompletedAssessmentUnscoredResponse = {
+  questionId: string;
+  questionCode: string;
+  questionText: string;
+  questionType: QuestionType;
+  reason: "question_type_not_scoreable" | "missing_numeric_option_value";
+};
+
+export type CompletedAssessmentResults = {
+  attemptId: string;
+  scoringMethod: ScoringMethod;
+  dimensions: CompletedAssessmentResultDimension[];
+  scoredResponseCount: number;
+  unscoredResponses: CompletedAssessmentUnscoredResponse[];
+};
+
+type ComputedResponseScore = {
+  responseId: string;
+  rawValue: number | null;
+  scoredValue: number | null;
+};
+
+type ComputedDimensionScore = {
+  dimension: string;
+  rawScore: number;
+  scoredQuestionCount: number;
+  sortOrder: number;
+};
+
+function roundScore(value: number): number {
+  return Math.round(value * 100) / 100;
+}
+
+function valuesEqual(left: number | null, right: number | null): boolean {
+  if (left === null || right === null) {
+    return left === right;
+  }
+
+  return roundScore(left) === roundScore(right);
+}
+
+function getLikertScaleBounds(options: AnswerOptionRecord[]): { min: number; max: number } | null {
+  const numericValues = options
+    .map((option) => option.value)
+    .filter((value): value is number => typeof value === "number");
+
+  if (numericValues.length === 0) {
+    return null;
+  }
+
+  return {
+    min: Math.min(...numericValues),
+    max: Math.max(...numericValues),
+  };
+}
+
+function computeLikertResults(
+  questions: QuestionRecord[],
+  answerOptions: AnswerOptionRecord[],
+  responses: ResponseRecord[],
+): {
+  responseScores: ComputedResponseScore[];
+  dimensions: ComputedDimensionScore[];
+  scoredResponseCount: number;
+  unscoredResponses: CompletedAssessmentUnscoredResponse[];
+} {
+  const questionsById = new Map(questions.map((question) => [question.id, question]));
+  const optionsById = new Map(answerOptions.map((option) => [option.id, option]));
+  const answerOptionsByQuestionId = answerOptions.reduce<Map<string, AnswerOptionRecord[]>>(
+    (groupedOptions, option) => {
+      const questionOptions = groupedOptions.get(option.question_id) ?? [];
+      questionOptions.push(option);
+      groupedOptions.set(option.question_id, questionOptions);
+      return groupedOptions;
+    },
+    new Map<string, AnswerOptionRecord[]>(),
+  );
+
+  const dimensionsByName = new Map<string, ComputedDimensionScore>();
+  const responseScores: ComputedResponseScore[] = [];
+  const unscoredResponses: CompletedAssessmentUnscoredResponse[] = [];
+  let scoredResponseCount = 0;
+
+  for (const response of responses) {
+    const question = questionsById.get(response.question_id);
+
+    if (!question) {
+      continue;
+    }
+
+    if (response.response_kind !== "single_choice") {
+      responseScores.push({
+        responseId: response.id,
+        rawValue: null,
+        scoredValue: null,
+      });
+      unscoredResponses.push({
+        questionId: question.id,
+        questionCode: question.code,
+        questionText: question.text,
+        questionType: question.question_type,
+        reason: "question_type_not_scoreable",
+      });
+      continue;
+    }
+
+    const selectedOption = response.answer_option_id
+      ? optionsById.get(response.answer_option_id)
+      : null;
+    const scaleBounds = getLikertScaleBounds(answerOptionsByQuestionId.get(question.id) ?? []);
+
+    if (!selectedOption || selectedOption.value === null || !scaleBounds) {
+      responseScores.push({
+        responseId: response.id,
+        rawValue: null,
+        scoredValue: null,
+      });
+      unscoredResponses.push({
+        questionId: question.id,
+        questionCode: question.code,
+        questionText: question.text,
+        questionType: question.question_type,
+        reason: "missing_numeric_option_value",
+      });
+      continue;
+    }
+
+    const rawValue = selectedOption.value;
+    const scoredValue = question.reverse_scored
+      ? scaleBounds.min + scaleBounds.max - rawValue
+      : rawValue;
+
+    responseScores.push({
+      responseId: response.id,
+      rawValue,
+      scoredValue,
+    });
+
+    const dimensionScore = dimensionsByName.get(question.dimension) ?? {
+      dimension: question.dimension,
+      rawScore: 0,
+      scoredQuestionCount: 0,
+      sortOrder: question.question_order,
+    };
+
+    dimensionScore.rawScore = roundScore(dimensionScore.rawScore + scoredValue * question.weight);
+    dimensionScore.scoredQuestionCount += 1;
+    dimensionScore.sortOrder = Math.min(dimensionScore.sortOrder, question.question_order);
+    dimensionsByName.set(question.dimension, dimensionScore);
+    scoredResponseCount += 1;
+  }
+
+  return {
+    responseScores,
+    dimensions: [...dimensionsByName.values()].sort((left, right) => left.sortOrder - right.sortOrder),
+    scoredResponseCount,
+    unscoredResponses,
+  };
+}
+
+async function loadScoringInputs(testId: string, attemptId: string) {
+  const supabase = createSupabaseAdminClient();
+
+  const { data: attemptData, error: attemptError } = await supabase
+    .from("attempts")
+    .select("id, status")
+    .eq("id", attemptId)
+    .eq("test_id", testId)
+    .maybeSingle();
+
+  if (attemptError) {
+    throw new Error(`Failed to load attempt for scoring: ${attemptError.message}`);
+  }
+
+  const attempt = attemptData as AttemptRecord | null;
+
+  if (!attempt || attempt.status !== "completed") {
+    return null;
+  }
+
+  const { data: testData, error: testError } = await supabase
+    .from("tests")
+    .select("id, scoring_method")
+    .eq("id", testId)
+    .single();
+
+  if (testError || !testData) {
+    throw new Error(
+      `Failed to load test scoring configuration: ${testError?.message ?? "Unknown error"}`,
+    );
+  }
+
+  const { data: questionsData, error: questionsError } = await supabase
+    .from("questions")
+    .select("id, code, text, dimension, question_type, question_order, reverse_scored, weight")
+    .eq("test_id", testId)
+    .order("question_order", { ascending: true });
+
+  if (questionsError) {
+    throw new Error(`Failed to load questions for scoring: ${questionsError.message}`);
+  }
+
+  const questions = (questionsData ?? []) as QuestionRecord[];
+  const questionIds = questions.map((question) => question.id);
+
+  const { data: answerOptionsData, error: answerOptionsError } = await supabase
+    .from("answer_options")
+    .select("id, question_id, value")
+    .in("question_id", questionIds);
+
+  if (answerOptionsError) {
+    throw new Error(`Failed to load answer options for scoring: ${answerOptionsError.message}`);
+  }
+
+  const { data: responsesData, error: responsesError } = await supabase
+    .from("responses")
+    .select("id, question_id, response_kind, answer_option_id, raw_value, scored_value")
+    .eq("attempt_id", attemptId);
+
+  if (responsesError) {
+    throw new Error(`Failed to load responses for scoring: ${responsesError.message}`);
+  }
+
+  return {
+    supabase,
+    test: testData as TestRecord,
+    questions,
+    answerOptions: (answerOptionsData ?? []) as AnswerOptionRecord[],
+    responses: (responsesData ?? []) as ResponseRecord[],
+  };
+}
+
+export async function calculateCompletedAssessmentResults(
+  testId: string,
+  attemptId: string,
+): Promise<CompletedAssessmentResults | null> {
+  const scoringInputs = await loadScoringInputs(testId, attemptId);
+
+  if (!scoringInputs) {
+    return null;
+  }
+
+  if (scoringInputs.test.scoring_method !== "likert_sum") {
+    throw new Error(
+      `Unsupported scoring method for MVP results flow: ${scoringInputs.test.scoring_method}`,
+    );
+  }
+
+  const computedResults = computeLikertResults(
+    scoringInputs.questions,
+    scoringInputs.answerOptions,
+    scoringInputs.responses,
+  );
+
+  return {
+    attemptId,
+    scoringMethod: scoringInputs.test.scoring_method,
+    dimensions: computedResults.dimensions.map((dimension) => ({
+      dimension: dimension.dimension,
+      rawScore: dimension.rawScore,
+      scoredQuestionCount: dimension.scoredQuestionCount,
+    })),
+    scoredResponseCount: computedResults.scoredResponseCount,
+    unscoredResponses: computedResults.unscoredResponses,
+  };
+}
+
+export async function persistCompletedAssessmentResults(
+  testId: string,
+  attemptId: string,
+): Promise<CompletedAssessmentResults | null> {
+  const scoringInputs = await loadScoringInputs(testId, attemptId);
+
+  if (!scoringInputs) {
+    return null;
+  }
+
+  if (scoringInputs.test.scoring_method !== "likert_sum") {
+    throw new Error(
+      `Unsupported scoring method for MVP results flow: ${scoringInputs.test.scoring_method}`,
+    );
+  }
+
+  const computedResults = computeLikertResults(
+    scoringInputs.questions,
+    scoringInputs.answerOptions,
+    scoringInputs.responses,
+  );
+
+  const responsesById = new Map(scoringInputs.responses.map((response) => [response.id, response]));
+  const responseUpdates = computedResults.responseScores.filter((score) => {
+    const existingResponse = responsesById.get(score.responseId);
+
+    if (!existingResponse) {
+      return false;
+    }
+
+    return (
+      !valuesEqual(existingResponse.raw_value, score.rawValue) ||
+      !valuesEqual(existingResponse.scored_value, score.scoredValue)
+    );
+  });
+
+  for (const responseUpdate of responseUpdates) {
+    const { error: responseUpdateError } = await scoringInputs.supabase
+      .from("responses")
+      .update({
+        raw_value: responseUpdate.rawValue,
+        scored_value: responseUpdate.scoredValue,
+      })
+      .eq("id", responseUpdate.responseId);
+
+    if (responseUpdateError) {
+      throw new Error(`Failed to persist response score: ${responseUpdateError.message}`);
+    }
+  }
+
+  const { error: deleteScoresError } = await scoringInputs.supabase
+    .from("dimension_scores")
+    .delete()
+    .eq("attempt_id", attemptId);
+
+  if (deleteScoresError) {
+    throw new Error(`Failed to replace dimension scores: ${deleteScoresError.message}`);
+  }
+
+  if (computedResults.dimensions.length > 0) {
+    const { error: insertScoresError } = await scoringInputs.supabase
+      .from("dimension_scores")
+      .insert(
+        computedResults.dimensions.map((dimension) => ({
+          attempt_id: attemptId,
+          dimension: dimension.dimension,
+          raw_score: dimension.rawScore,
+          normalized_score: null,
+          percentile_score: null,
+          interpretation: null,
+        })),
+      );
+
+    if (insertScoresError) {
+      throw new Error(`Failed to persist dimension scores: ${insertScoresError.message}`);
+    }
+  }
+
+  return {
+    attemptId,
+    scoringMethod: scoringInputs.test.scoring_method,
+    dimensions: computedResults.dimensions.map((dimension) => ({
+      dimension: dimension.dimension,
+      rawScore: dimension.rawScore,
+      scoredQuestionCount: dimension.scoredQuestionCount,
+    })),
+    scoredResponseCount: computedResults.scoredResponseCount,
+    unscoredResponses: computedResults.unscoredResponses,
+  };
+}

--- a/lib/assessment/tests.ts
+++ b/lib/assessment/tests.ts
@@ -6,6 +6,11 @@ import type {
   QuestionType,
   Test,
 } from "@/lib/assessment/types";
+import {
+  calculateCompletedAssessmentResults,
+  persistCompletedAssessmentResults,
+  type CompletedAssessmentResults,
+} from "@/lib/assessment/scoring";
 import { createSupabaseAdminClient } from "@/lib/supabase/admin";
 import { createSupabaseServerClient } from "@/lib/supabase/server";
 
@@ -185,4 +190,39 @@ export async function getAssessmentResumeState(
     completedAt: resumeAttempt.completed_at,
     selections,
   };
+}
+
+export async function getCompletedAssessmentResults(
+  testId: string,
+  attemptId: string | null,
+): Promise<CompletedAssessmentResults | null> {
+  if (!attemptId) {
+    return null;
+  }
+
+  const results = await calculateCompletedAssessmentResults(testId, attemptId);
+
+  if (!results) {
+    return null;
+  }
+
+  if (results.dimensions.length === 0) {
+    return results;
+  }
+
+  const supabase = createSupabaseAdminClient();
+  const { count, error } = await supabase
+    .from("dimension_scores")
+    .select("id", { count: "exact", head: true })
+    .eq("attempt_id", attemptId);
+
+  if (error) {
+    throw new Error(`Failed to load persisted results: ${error.message}`);
+  }
+
+  if ((count ?? 0) === 0) {
+    return persistCompletedAssessmentResults(testId, attemptId);
+  }
+
+  return results;
 }

--- a/scripts/verify-completion-flow.mjs
+++ b/scripts/verify-completion-flow.mjs
@@ -2,8 +2,9 @@ import process from "node:process";
 import { setTimeout as delay } from "node:timers/promises";
 import { createClient } from "@supabase/supabase-js";
 
-const APP_URL = "http://127.0.0.1:3100";
+const APP_URL = process.env.APP_URL ?? "http://localhost:3100";
 const ATTEMPT_COOKIE_NAME = "assessment_attempt_id";
+const HEALTH_URL = `${APP_URL}/api/health`;
 const ACTIVE_TEST_SLUG = "big5-mini";
 
 function fail(message) {
@@ -47,21 +48,25 @@ async function fetchAssessmentPage(attemptId) {
 }
 
 async function waitForServer() {
-  for (let attempt = 0; attempt < 60; attempt += 1) {
+  let lastDetail = `No response from ${HEALTH_URL}.`;
+
+  for (let attempt = 0; attempt < 120; attempt += 1) {
     try {
-      const response = await fetch(APP_URL);
+      const response = await fetch(HEALTH_URL);
 
       if (response.ok) {
         return;
       }
-    } catch {
-      // Server is still starting.
+
+      lastDetail = `HTTP ${response.status} from ${HEALTH_URL}.`;
+    } catch (error) {
+      lastDetail = error instanceof Error ? error.message : String(error);
     }
 
     await delay(1000);
   }
 
-  fail("Next.js server did not become ready in time.");
+  fail(`Next.js server did not become ready at ${HEALTH_URL}. Last check: ${lastDetail}`);
 }
 
 async function main() {
@@ -258,3 +263,5 @@ main().catch((error) => {
   console.error(error instanceof Error ? error.message : String(error));
   process.exitCode = 1;
 });
+
+

--- a/scripts/verify-resume-flow.mjs
+++ b/scripts/verify-resume-flow.mjs
@@ -2,8 +2,9 @@ import process from "node:process";
 import { setTimeout as delay } from "node:timers/promises";
 import { createClient } from "@supabase/supabase-js";
 
-const APP_URL = "http://127.0.0.1:3100";
+const APP_URL = process.env.APP_URL ?? "http://localhost:3100";
 const ATTEMPT_COOKIE_NAME = "assessment_attempt_id";
+const HEALTH_URL = `${APP_URL}/api/health`;
 const ACTIVE_TEST_SLUG = "big5-mini";
 const TEMP_TEST_ID = "39999999-1111-1111-1111-111111111111";
 
@@ -41,10 +42,7 @@ function assertResumeAttemptId(html, attemptId) {
   assertIncludes(html, expectedSnippet, `Expected resume payload to contain ${expectedSnippet}.`);
 }
 
-function assertSelectionPresent(html, questionId, expectedValue) {
-  const questionSnippet = `\\"${questionId}\\":`;
-  assertIncludes(html, questionSnippet, `Expected resume payload to contain question ${questionId}.`);
-
+function assertSerializedSelection(html, questionId, expectedValue) {
   if (typeof expectedValue === "string") {
     assertIncludes(
       html,
@@ -54,13 +52,12 @@ function assertSelectionPresent(html, questionId, expectedValue) {
     return;
   }
 
-  for (const optionId of expectedValue) {
-    assertIncludes(
-      html,
-      optionId,
-      `Expected resume payload to contain option ${optionId} for ${questionId}.`,
-    );
-  }
+  const serializedArray = expectedValue.map((value) => `\\"${value}\\"`).join(",");
+  assertIncludes(
+    html,
+    `\\"${questionId}\\":[${serializedArray}]`,
+    `Expected resume payload to contain selection list for ${questionId}.`,
+  );
 }
 
 function assertSelectionsEmpty(html) {
@@ -86,21 +83,25 @@ async function fetchAssessmentPage(attemptId) {
 }
 
 async function waitForServer() {
-  for (let attempt = 0; attempt < 60; attempt += 1) {
+  let lastDetail = `No response from ${HEALTH_URL}.`;
+
+  for (let attempt = 0; attempt < 120; attempt += 1) {
     try {
-      const response = await fetch(APP_URL);
+      const response = await fetch(HEALTH_URL);
 
       if (response.ok) {
         return;
       }
-    } catch {
-      // Server is still starting.
+
+      lastDetail = `HTTP ${response.status} from ${HEALTH_URL}.`;
+    } catch (error) {
+      lastDetail = error instanceof Error ? error.message : String(error);
     }
 
     await delay(1000);
   }
 
-  fail("Next.js server did not become ready in time.");
+  fail(`Next.js server did not become ready at ${HEALTH_URL}. Last check: ${lastDetail}`);
 }
 
 async function saveSelections(supabase, testId, attemptId, selectionsByQuestionId, questionTypeById) {
@@ -342,9 +343,9 @@ async function main() {
 
   const initialHtml = await fetchAssessmentPage(attemptId);
   assertResumeAttemptId(initialHtml, attemptId);
-  assertSelectionPresent(initialHtml, singleQuestion.id, singleOptions[1].id);
-  assertSelectionPresent(initialHtml, multiQuestion.id, [multipleOptions[0].id, multipleOptions[1].id]);
-  assertSelectionPresent(initialHtml, textQuestion.id, "Initial resume verification text.");
+  assertSerializedSelection(initialHtml, singleQuestion.id, singleOptions[1].id);
+  assertSerializedSelection(initialHtml, multiQuestion.id, [multipleOptions[0].id, multipleOptions[1].id]);
+  assertSerializedSelection(initialHtml, textQuestion.id, "Initial resume verification text.");
   assertNotIncludes(
     initialHtml,
     `\\"${singleQuestion.id}\\":\\"${singleOptions[3].id}\\"`,
@@ -405,9 +406,9 @@ async function main() {
 
   const updatedHtml = await fetchAssessmentPage(attemptId);
   assertResumeAttemptId(updatedHtml, attemptId);
-  assertSelectionPresent(updatedHtml, singleQuestion.id, singleOptions[3].id);
-  assertSelectionPresent(updatedHtml, multiQuestion.id, [multipleOptions[2].id, multipleOptions[3].id]);
-  assertSelectionPresent(updatedHtml, textQuestion.id, "Updated resume verification text.");
+  assertSerializedSelection(updatedHtml, singleQuestion.id, singleOptions[3].id);
+  assertSerializedSelection(updatedHtml, multiQuestion.id, [multipleOptions[2].id, multipleOptions[3].id]);
+  assertSerializedSelection(updatedHtml, textQuestion.id, "Updated resume verification text.");
   assertNotIncludes(
     updatedHtml,
     `\\"${singleQuestion.id}\\":\\"${singleOptions[1].id}\\"`,
@@ -415,8 +416,8 @@ async function main() {
   );
   assertNotIncludes(
     updatedHtml,
-    multipleOptions[0].id,
-    "Updated resume payload still contained a stale multiple-choice option.",
+    `\\"${multiQuestion.id}\\":[\\"${multipleOptions[0].id}\\",\\"${multipleOptions[1].id}\\"]`,
+    "Updated resume payload still contained the stale multiple-choice selection array.",
   );
 
   const { error: deleteAttemptError } = await supabase

--- a/scripts/verify-scoring-flow.mjs
+++ b/scripts/verify-scoring-flow.mjs
@@ -1,0 +1,324 @@
+import process from "node:process";
+import { setTimeout as delay } from "node:timers/promises";
+import { createClient } from "@supabase/supabase-js";
+
+const APP_URL = process.env.APP_URL ?? "http://localhost:3100";
+const ATTEMPT_COOKIE_NAME = "assessment_attempt_id";
+const HEALTH_URL = `${APP_URL}/api/health`;
+const ACTIVE_TEST_SLUG = "big5-mini";
+
+function fail(message) {
+  throw new Error(message);
+}
+
+function getRequiredEnvVar(name) {
+  const value = process.env[name];
+
+  if (!value) {
+    fail(`Missing required env var: ${name}`);
+  }
+
+  return value;
+}
+
+function assertIncludes(haystack, needle, message) {
+  if (!haystack.includes(needle)) {
+    fail(message);
+  }
+}
+
+async function fetchAssessmentPage(attemptId) {
+  const response = await fetch(APP_URL, {
+    headers: {
+      cookie: `${ATTEMPT_COOKIE_NAME}=${attemptId}`,
+    },
+  });
+
+  if (!response.ok) {
+    fail(`Page request failed with status ${response.status}.`);
+  }
+
+  return response.text();
+}
+
+async function waitForServer() {
+  let lastDetail = `No response from ${HEALTH_URL}.`;
+
+  for (let attempt = 0; attempt < 120; attempt += 1) {
+    try {
+      const response = await fetch(HEALTH_URL);
+
+      if (response.ok) {
+        return;
+      }
+
+      lastDetail = `HTTP ${response.status} from ${HEALTH_URL}.`;
+    } catch (error) {
+      lastDetail = error instanceof Error ? error.message : String(error);
+    }
+
+    await delay(1000);
+  }
+
+  fail(`Next.js server did not become ready at ${HEALTH_URL}. Last check: ${lastDetail}`);
+}
+
+async function main() {
+  const supabaseUrl = getRequiredEnvVar("NEXT_PUBLIC_SUPABASE_URL");
+  const serviceRoleKey = getRequiredEnvVar("SUPABASE_SERVICE_ROLE_KEY");
+  const supabase = createClient(supabaseUrl, serviceRoleKey, {
+    auth: {
+      autoRefreshToken: false,
+      persistSession: false,
+    },
+  });
+
+  await waitForServer();
+
+  const { data: activeTest, error: activeTestError } = await supabase
+    .from("tests")
+    .select("id")
+    .eq("slug", ACTIVE_TEST_SLUG)
+    .single();
+
+  if (activeTestError || !activeTest) {
+    fail(`Unable to load active test: ${activeTestError?.message ?? "Unknown error"}`);
+  }
+
+  const { data: questions, error: questionsError } = await supabase
+    .from("questions")
+    .select("id, code, question_type")
+    .eq("test_id", activeTest.id)
+    .order("question_order", { ascending: true });
+
+  if (questionsError || !questions) {
+    fail(`Unable to load questions: ${questionsError?.message ?? "Unknown error"}`);
+  }
+
+  const questionByCode = new Map(questions.map((question) => [question.code, question]));
+  const requiredCodes = ["E1", "E2", "C1", "C2", "A1", "O1"];
+
+  for (const code of requiredCodes) {
+    if (!questionByCode.has(code)) {
+      fail(`Expected seeded question ${code} was not found.`);
+    }
+  }
+
+  const scoredQuestionIds = ["E1", "E2", "C1", "C2"].map((code) => questionByCode.get(code).id);
+  const unscoredQuestionIds = [questionByCode.get("A1").id, questionByCode.get("O1").id];
+
+  const { data: answerOptions, error: answerOptionsError } = await supabase
+    .from("answer_options")
+    .select("id, question_id, option_order")
+    .in("question_id", [...scoredQuestionIds, questionByCode.get("A1").id])
+    .order("option_order", { ascending: true });
+
+  if (answerOptionsError || !answerOptions) {
+    fail(`Unable to load answer options: ${answerOptionsError?.message ?? "Unknown error"}`);
+  }
+
+  const answerOptionsByQuestionId = answerOptions.reduce((grouped, option) => {
+    const questionOptions = grouped.get(option.question_id) ?? [];
+    questionOptions.push(option);
+    grouped.set(option.question_id, questionOptions);
+    return grouped;
+  }, new Map());
+
+  const e1Option = answerOptionsByQuestionId.get(questionByCode.get("E1").id)?.[4];
+  const e2Option = answerOptionsByQuestionId.get(questionByCode.get("E2").id)?.[3];
+  const c1Option = answerOptionsByQuestionId.get(questionByCode.get("C1").id)?.[2];
+  const c2Option = answerOptionsByQuestionId.get(questionByCode.get("C2").id)?.[1];
+  const multiOptions = answerOptionsByQuestionId.get(questionByCode.get("A1").id) ?? [];
+
+  if (!e1Option || !e2Option || !c1Option || !c2Option || multiOptions.length < 2) {
+    fail("Expected seeded answer options for scoring verification were not found.");
+  }
+
+  const { data: attemptData, error: attemptError } = await supabase
+    .from("attempts")
+    .insert({ test_id: activeTest.id, status: "completed", completed_at: new Date().toISOString() })
+    .select("id")
+    .single();
+
+  if (attemptError || !attemptData) {
+    fail(`Unable to create completed attempt: ${attemptError?.message ?? "Unknown error"}`);
+  }
+
+  const attemptId = attemptData.id;
+
+  const { data: responseData, error: responseError } = await supabase
+    .from("responses")
+    .insert([
+      {
+        attempt_id: attemptId,
+        question_id: questionByCode.get("E1").id,
+        response_kind: "single_choice",
+        answer_option_id: e1Option.id,
+      },
+      {
+        attempt_id: attemptId,
+        question_id: questionByCode.get("E2").id,
+        response_kind: "single_choice",
+        answer_option_id: e2Option.id,
+      },
+      {
+        attempt_id: attemptId,
+        question_id: questionByCode.get("C1").id,
+        response_kind: "single_choice",
+        answer_option_id: c1Option.id,
+      },
+      {
+        attempt_id: attemptId,
+        question_id: questionByCode.get("C2").id,
+        response_kind: "single_choice",
+        answer_option_id: c2Option.id,
+      },
+      {
+        attempt_id: attemptId,
+        question_id: questionByCode.get("A1").id,
+        response_kind: "multiple_choice",
+      },
+      {
+        attempt_id: attemptId,
+        question_id: questionByCode.get("O1").id,
+        response_kind: "text",
+        text_value: "Scoring verification text.",
+      },
+    ])
+    .select("id, question_id, response_kind");
+
+  if (responseError || !responseData) {
+    fail(`Unable to create responses: ${responseError?.message ?? "Unknown error"}`);
+  }
+
+  const multipleChoiceParent = responseData.find(
+    (response) =>
+      response.question_id === questionByCode.get("A1").id && response.response_kind === "multiple_choice",
+  );
+
+  if (!multipleChoiceParent) {
+    fail("Multiple choice parent response was not created.");
+  }
+
+  const { error: selectionError } = await supabase
+    .from("response_selections")
+    .insert([
+      {
+        response_id: multipleChoiceParent.id,
+        question_id: questionByCode.get("A1").id,
+        answer_option_id: multiOptions[0].id,
+      },
+      {
+        response_id: multipleChoiceParent.id,
+        question_id: questionByCode.get("A1").id,
+        answer_option_id: multiOptions[1].id,
+      },
+    ]);
+
+  if (selectionError) {
+    fail(`Unable to create response selections: ${selectionError.message}`);
+  }
+
+  const html = await fetchAssessmentPage(attemptId);
+  assertIncludes(html, "Results", "Expected results section to render for a completed attempt.");
+  assertIncludes(html, "Scored responses", "Expected scored response summary to render.");
+  assertIncludes(html, "Extraversion", "Expected Extraversion result to render.");
+  assertIncludes(html, "Conscientiousness", "Expected Conscientiousness result to render.");
+  assertIncludes(
+    html,
+    "Recorded but unscored responses",
+    "Expected completed results to explain unscored response types.",
+  );
+  assertIncludes(html, "A1", "Expected unscored multiple choice question to be listed.");
+  assertIncludes(html, "O1", "Expected unscored text question to be listed.");
+  assertIncludes(html, "Scoring verification text.", "Expected saved text response to remain visible.");
+
+  const { data: scoredResponses, error: scoredResponsesError } = await supabase
+    .from("responses")
+    .select("question_id, raw_value, scored_value")
+    .eq("attempt_id", attemptId);
+
+  if (scoredResponsesError || !scoredResponses) {
+    fail(`Unable to reload scored responses: ${scoredResponsesError?.message ?? "Unknown error"}`);
+  }
+
+  const scoredResponseByQuestionId = new Map(
+    scoredResponses.map((response) => [response.question_id, response]),
+  );
+
+  const expectedScores = new Map([
+    [questionByCode.get("E1").id, { raw: 5, scored: 5 }],
+    [questionByCode.get("E2").id, { raw: 4, scored: 2 }],
+    [questionByCode.get("C1").id, { raw: 3, scored: 3 }],
+    [questionByCode.get("C2").id, { raw: 2, scored: 4 }],
+  ]);
+
+  for (const [questionId, expectedScore] of expectedScores.entries()) {
+    const response = scoredResponseByQuestionId.get(questionId);
+
+    if (!response) {
+      fail(`Missing scored response for question ${questionId}.`);
+    }
+
+    if (response.raw_value !== expectedScore.raw || response.scored_value !== expectedScore.scored) {
+      fail(`Unexpected stored response score for question ${questionId}.`);
+    }
+  }
+
+  for (const questionId of unscoredQuestionIds) {
+    const response = scoredResponseByQuestionId.get(questionId);
+
+    if (!response) {
+      fail(`Missing unscored response for question ${questionId}.`);
+    }
+
+    if (response.raw_value !== null || response.scored_value !== null) {
+      fail(`Unscored question ${questionId} should not receive numeric scores.`);
+    }
+  }
+
+  const { data: dimensionScores, error: dimensionScoresError } = await supabase
+    .from("dimension_scores")
+    .select("dimension, raw_score")
+    .eq("attempt_id", attemptId)
+    .order("dimension", { ascending: true });
+
+  if (dimensionScoresError || !dimensionScores) {
+    fail(`Unable to load dimension scores: ${dimensionScoresError?.message ?? "Unknown error"}`);
+  }
+
+  if (dimensionScores.length !== 2) {
+    fail(`Expected 2 persisted dimension scores, received ${dimensionScores.length}.`);
+  }
+
+  const dimensionScoreByName = new Map(
+    dimensionScores.map((dimensionScore) => [dimensionScore.dimension, Number(dimensionScore.raw_score)]),
+  );
+
+  if (dimensionScoreByName.get("conscientiousness") !== 7) {
+    fail("Expected conscientiousness raw score to persist as 7.");
+  }
+
+  if (dimensionScoreByName.get("extraversion") !== 7) {
+    fail("Expected extraversion raw score to persist as 7.");
+  }
+
+  const reloadHtml = await fetchAssessmentPage(attemptId);
+  assertIncludes(reloadHtml, "Results", "Expected results section to remain on reload.");
+  assertIncludes(reloadHtml, "Scored responses", "Expected persisted results summary to remain on reload.");
+
+  console.log("Scoring flow verification passed.");
+  console.log(`Verified attempt id: ${attemptId}`);
+  console.log("Verified behaviors:");
+  console.log("- completed attempt results are derived server-side from persisted responses");
+  console.log("- response raw_value and scored_value are persisted only for scoreable single-choice items");
+  console.log("- dimension_scores are persisted for completed attempts and remain stable on reload");
+  console.log("- multiple_choice and text responses remain explicit recorded-but-unscored inputs");
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error));
+  process.exitCode = 1;
+});
+
+


### PR DESCRIPTION
PR TITLE:
feat: implement verified scoring and results flow

PR DESCRIPTION:
## Summary
This PR implements a server-backed scoring and results flow for completed assessment attempts, while preserving the existing save, resume, and completion contracts.

## What changed
- added a dedicated scoring layer in `lib/assessment/scoring.ts`
- updated assessment read/write flow to support persisted scoring results
- updated assessment UI to show results for completed attempts
- added `scripts/verify-scoring-flow.mjs`
- added `/api/health` readiness endpoint
- hardened verification scripts to use `process.env.APP_URL ?? "http://localhost:3100"` and probe `/api/health`

## Behavior
- scoring is derived from persisted response truth
- current MVP scoring supports the seeded Big Five `likert_sum` model
- scoreable inputs are `single_choice` responses joined to numeric `answer_options.value`
- scoring uses:
  - `questions.reverse_scored`
  - `questions.dimension`
  - `questions.weight`
- `multiple_choice` and `text` remain persisted but unscored in this MVP
- completed attempts reload with stable results
- if persisted completed-attempt rollups are missing, they are backfilled server-side and then reused

## Architecture notes
- no schema changes
- existing `responses` / `response_selections` model remains unchanged
- completion contract remains unchanged
- results stay backed by database truth, not client-only calculation

## Validation
- `npx supabase db reset`
- `npm run check:supabase`
- `npm run typecheck`
- `npm run lint`
- `node --env-file=.env.local scripts/verify-resume-flow.mjs`
- `node --env-file=.env.local scripts/verify-completion-flow.mjs`
- `node --env-file=.env.local scripts/verify-scoring-flow.mjs`

## Deferred / intentionally unsupported
- only `likert_sum` is implemented for this MVP
- `correct_answers` and `weighted_correct` remain unsupported
- `multiple_choice` and `text` are recorded but not scored because the current schema/seed does not define numeric scoring truth for them
- no normalization, percentile logic, or interpretation layer yet